### PR TITLE
Kk start order

### DIFF
--- a/src/modules/orderManager.js
+++ b/src/modules/orderManager.js
@@ -1,0 +1,14 @@
+import baseurl from "./baseurl"
+
+export default{
+    getOrders(token){
+        return fetch(`${baseurl}/orders`, {
+            method: "GET",
+            headers: {
+                'content-type': "application/json",
+                'Accept': "application/json",
+                'Authorization': `Token ${token}`
+            } 
+        })
+    }
+}

--- a/src/modules/orderManager.js
+++ b/src/modules/orderManager.js
@@ -9,6 +9,16 @@ export default{
                 'Accept': "application/json",
                 'Authorization': `Token ${token}`
             } 
-        })
+        }).then(r=>r.json())
+    },
+    postOrder(token){
+        return fetch(`${baseurl}/orders`, {
+            method: "POST",
+            headers: {
+                'content-type': "application/json",
+                'Accept': 'application/json',
+                'Authorization': `Token ${token}`
+            }
+        }).then(r=>r.json())
     }
 }

--- a/src/modules/order_product_manager.js
+++ b/src/modules/order_product_manager.js
@@ -1,0 +1,15 @@
+import baseurl from "./baseurl"
+
+export default{
+    postNewOrder(token, obj){
+        return fetch(`${baseurl}/order_products`, {
+            method: "POST",
+            headers: {
+                'content-type': 'application/json',
+                'Accept': "application/json",
+                'Authorization': `Token ${token}`
+            },
+            body: JSON.stringify(obj)
+        }).then(r=> r.json())
+    }
+}

--- a/src/pages/products/productDetails.js
+++ b/src/pages/products/productDetails.js
@@ -13,6 +13,7 @@ const ProductDetails = props => {
 
     const handleAddToCard= productId=> {
         orderManager.getOrders(token).then(arr=> {
+            if (arr.length>0){
             if(arr[0].payment_type_id != null){
                 console.log('lets make a new order')
                 orderManager.postOrder(token).then(obj=> {
@@ -20,14 +21,23 @@ const ProductDetails = props => {
                         "order_id": obj.id,
                         "product_id": productId
                     }
-                    order_product_manager.postNewOrder(token, productRelationship).then(()=> console.log('you started a new order and added a thing'))
+                    order_product_manager.postNewOrder(token, productRelationship)
                 })
             } else{
                 const productRelationship = {
                     "order_id": arr[0].id,
                     "product_id": productId
                 }
-                order_product_manager.postNewOrder(token, productRelationship).then(()=> console.log('you added a new thing to your order'))
+                order_product_manager.postNewOrder(token, productRelationship)
+            }}
+            else{
+                orderManager.postOrder(token).then(obj=> {
+                    const productRelationship = {
+                        "order_id": obj.id,
+                        "product_id": productId
+                    }
+                    order_product_manager.postNewOrder(token, productRelationship)
+                })
             }
         })
     }

--- a/src/pages/products/productDetails.js
+++ b/src/pages/products/productDetails.js
@@ -2,16 +2,34 @@
 
 import React, {useState, useEffect} from 'react';
 import productManager from "../../modules/productManager"
+import orderManager  from "../../modules/orderManager";
+import order_product_manager from "../../modules/order_product_manager"
 import "./productDetails.css"
 import IconButton from '@material-ui/core/IconButton';
 
 const ProductDetails = props => {
     const [product, setProduct] = useState({})
-    const [order, SetOrder] = useState({})
     const token = sessionStorage.getItem('token')
 
     const handleAddToCard= productId=> {
-
+        orderManager.getOrders(token).then(arr=> {
+            if(arr[0].payment_type_id != null){
+                console.log('lets make a new order')
+                orderManager.postOrder(token).then(obj=> {
+                    const productRelationship = {
+                        "order_id": obj.id,
+                        "product_id": productId
+                    }
+                    order_product_manager.postNewOrder(token, productRelationship).then(()=> console.log('you started a new order and added a thing'))
+                })
+            } else{
+                const productRelationship = {
+                    "order_id": arr[0].id,
+                    "product_id": productId
+                }
+                order_product_manager.postNewOrder(token, productRelationship).then(()=> console.log('you added a new thing to your order'))
+            }
+        })
     }
 
     useEffect(()=> {
@@ -40,7 +58,7 @@ const ProductDetails = props => {
             </div>
             
             <div className="icon-container-details">
-            <button className="ui button" onClick={()=> console.log("add to card")}>Add To Cart</button>
+            <button className="ui button" onClick={()=> handleAddToCard(product.id)}>Add To Cart</button>
             </div>
         </div>
         </div>

--- a/src/pages/products/productDetails.js
+++ b/src/pages/products/productDetails.js
@@ -7,6 +7,12 @@ import IconButton from '@material-ui/core/IconButton';
 
 const ProductDetails = props => {
     const [product, setProduct] = useState({})
+    const [order, SetOrder] = useState({})
+    const token = sessionStorage.getItem('token')
+
+    const handleAddToCard= productId=> {
+
+    }
 
     useEffect(()=> {
         //fetch the product here


### PR DESCRIPTION
Fixes #13 section b (adding items to cart)

# Fetching Instructions
```shell
git fetch --all
git checkout kk-start-order
```

# Description
Users can now click add to cart (on the product details page only I will eventually add to home page as a stretch goal). If the user currently has an order open it will add the current product to that order and if it will create a new order and add the product to that order. 

# List of changes
- created Orders view and Order_product views (list and create only)
- update URLS.py 


# Testing:
- must be authenticated in the React app to add product to cart or the app will crash

- Once on my branch you need use Postman to view changes because we do not have a order view end point yet. below are the urls you will use to see the changes
-  `localhost:8000/order_products`
- `localhost:8000/orders`
- to full test go to the details page of a product and click "Add to Cart" if you do no have a current open order it will create a new one and then add that product
- add another product and see that it gets added to the same order 
- in TablePlus change the payment_type_id of that most recent order to 1, 2 or 3 and the see that creates a new order

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation specific to my parts
- [ ] My changes generate no new warnings