### PR TITLE
warning appears if price is over 10k

### DIFF
--- a/src/pages/products/ProductForm.js
+++ b/src/pages/products/ProductForm.js
@@ -56,6 +56,8 @@ const ProductForm = (props) => {
       alert("The image URL field must contain text.");
     } else if (newProduct.price.length === 0) {
       alert("The price field must contain a number.");
+    } else if (newProduct.price > 10000) {
+      alert("The listing price may not exceed $10,000.00");
     } else if (newProduct.quantity.length === 0) {
       alert("The quantity field must contain a number.");
     } else {


### PR DESCRIPTION
Fixes #24 

# Fetching Instructions
```shell
git fetch --all
git checkout ag-product-price-under-10k
```

# Description
Changed the product form to provide an alert if the product price is over $10,000.00


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation specific to my parts
- [x] My changes generate no new warnings