### PR TITLE
added button to cancel order

### DIFF
--- a/src/modules/orderManager.js
+++ b/src/modules/orderManager.js
@@ -31,5 +31,14 @@ export default{
             },
             body: JSON.stringify(obj)
         })
+    },
+    deleteOrder(token, id){
+        return fetch(`${baseurl}/orders/${id}`, {
+            method: "DELETE",
+            headers: {
+                "content-type": "application/json",
+                "Authorization": `Token ${token}`
+            }
+        })
     }
 }

--- a/src/pages/orders/mycart.js
+++ b/src/pages/orders/mycart.js
@@ -20,6 +20,9 @@ const MyCart = props => {
             setReload(!reload)
         })
     }
+    const deleteWholeOrder=(id)=>{
+        OrderManager.deleteOrder(token, id).then(()=> props.history.push('/'))
+    }
 
     useEffect(()=> {
 //I start by grabbing all the orders and ten I see if there more than 0 orders and if so i check to see if there is an open order by seeing
@@ -64,7 +67,9 @@ const MyCart = props => {
                     </Card.Group>
                 </div>
                 <div className="cart-button-container">
-                    <button  class="ui primary button" onClick={()=> props.history.push('/checkout')}>Checkout</button>
+                    
+                    <button  className="ui primary button" onClick={()=> props.history.push('/checkout')}>Checkout</button>
+                    {order.order != null ? <button  className="ui primary button" onClick={()=> deleteWholeOrder(order["order"].id)}>Cancel Order</button> : (<></>)}
                 </div>
             </div>
             </>


### PR DESCRIPTION
Fixes #9 

# Fetching Instructions
```shell
git fetch --all
git checkout kk-cancel-order
```

# Description
Please include a summary of the change and which issue is fixed.
A user can now click cancel order in the cart and the order itself (along with the product-order-relationships) will be deleted. 

# List of changes
- Added a button and a function to the MyCart.js in react side
- Added a delete endpoint in orders viewset 
- Added a testing folder called tests that holds all the tests. 
- to test open the api and run `python manage.py test`
- to view run the server
- open postman
-run the react app 
- create an order by adding products to it
- go to post man and go to localhost:8000/orders to see you most recent order
- note the ID***
- now in a new tab in postman go to localhost:8000/order_products?order_id={YOUR ID}
-in the react app when you click delete you should be redirected to the home page and your cart should be empty
- in postman you should refresh the order_products link and see an empty array (the products should still exist just not the relationship)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation specific to my parts
- [x] My changes generate no new warnings