### PR TITLE
Kk product details 2

### DIFF
--- a/src/components/cards/MyListCard.js
+++ b/src/components/cards/MyListCard.js
@@ -46,36 +46,6 @@ export default function MyListCard(props) {
     const handleExpandClick = () => {
       setExpanded(!expanded);
     };
-  if (props.product.id%5===0 ){
-    //this returns a different card to break up the same cards from displaying to the dom (same information but adds price)
-    return(
-      <div className="custom-card">
-        <div className="cc-left">
-        <div
-            className="cc-img"
-            style={{
-              backgroundImage: `url(${props.product.image_path})`,
-              backgroundPosition: "center",
-              backgroundSize: "cover",
-              backgroundRepeat: "no-repeat",
-            }}
-          >
-          </div>
-        </div>
-        <div className="cc-right">
-        <div className="cc-title">{props.product.title}</div><p className="text">{props.product.description}</p>
-          <div className="cc-price">Only ${props.product.price}</div>
-          <div className="cc-prod-buttons">
-          <Button basic color='red' onClick={()=> props.deleteThisProduct(props.product.id)}>
-            Remove
-          </Button>
-          <button className="ui button" onClick={()=> props.history.push(`/products/${props.product.id}`)}>See More</button>
-          </div>
-        </div>
-      </div>
-    )
-
-  }else{
     return (
       <Card className={classes.root} id="home-card">
         <CardHeader
@@ -96,6 +66,12 @@ export default function MyListCard(props) {
           <Typography variant="body2" color="textSecondary" component="div">
             <p className="text">{props.product.description}</p>
           </Typography>
+          <Typography variant="body2" color="textSecondary" component="div">
+            <p className="text"> Stock: {props.product.quantity}</p>
+          </Typography>
+          <Typography variant="body2" color="textSecondary" component="div">
+            <p className="text"> Amount Sold: {props.product.amount_sold}</p>
+          </Typography>
         </CardContent>
         <CardActions disableSpacing className="prod-card-button-container">
           <Button basic color='red' onClick={()=> props.deleteThisProduct(props.product.id)}>
@@ -106,4 +82,3 @@ export default function MyListCard(props) {
       </Card>
     );
   }
-}

--- a/src/pages/orders/depleteProduct.js
+++ b/src/pages/orders/depleteProduct.js
@@ -3,20 +3,21 @@ import PM from "../../modules/productManager"
 
 const depleteProduct=(arr, token)=> {
 
+    const obj = {}
     for(let i=0; i<arr.length; i++){
-        let updatedProduct = {...arr[i]}
-        if(updatedProduct.quantity===0){
-            return {'error': `product is out of stock`, 'id': updatedProduct.id}
-        }else {
-            PM.getOneProduct(arr[i].product.id).then(obj=> {
-                const newObj = obj
-                newObj.quantity = obj.quantity - 1
-                PM.updateQuantity(token, newObj)
-            })
-            // updatedProduct.quantity = updatedProduct.quantity -1
-            // console.log(updatedProduct)
-            // PM.updateQuantity(token, updatedProduct)
+        if(!obj[arr[i].product.id]){
+            obj[arr[i].product.id] = 1
+        } else{
+            obj[arr[i].product.id] +=1
         }
     }
+
+    for (let [productId, value] of Object.entries(obj)) {
+        PM.getOneProduct(productId).then(newObj=> {
+                newObj.quantity-= value
+                PM.updateQuantity(token, newObj)
+            })
+      }
+    
 }
 export default depleteProduct


### PR DESCRIPTION
Fixes #15 

# Fetching Instructions
```shell
git fetch --all
git checkout kk-products-details-2
```

# Description
Here I listed how many products have been sold and the quantity remaining in the 'My Products' tab. I also fixed the bug when a user buys two products it only removed one. Now, it will remove 2 or however many a user buys (haven't fixed the negative quantity issue yet)


# List of changes
- Added `amount_sold = 0` to product model (you shouldn't need to make migrations)
- added loop in products list that changes that number from 0 to x (however many products have been sold based off of order_products table with an order that has a payment_type_id)
- altered MyListCard.js to only have one kind of card getting placed to the dom as well as showing that specific products quantity and amount sold
- added testing to the end point for products list

# How to test
- open app as normal (npm start && pym runserver) 
- test that amount sold under (my products tab is showing the accurate amount) 
- 'sell' one product and test that it reflects that on the page
- checkout with 2 of the same products and see that the quantity reflects that
- lastly in the api terminal run the `python manage.py test` and be sure no errors pop up.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation specific to my parts
- [x] My changes generate no new warnings