### PR TITLE
Tct vertical responsive

### DIFF
--- a/src/components/expansion/Expansion.js
+++ b/src/components/expansion/Expansion.js
@@ -28,7 +28,7 @@ export default function SimpleExpansionPanel({
   return (
     <div className={`${className} expansion-panel`}>
       <ExpansionPanel expanded={isOpen}>
-        {isOpen ? (
+        {routeClose ? (
           <Link to={isOpen ? routeClose : routeOpen}>
             <ExpansionPanelSummary
               expandIcon={<ExpandMoreIcon />}

--- a/src/components/expansion/Expansion.js
+++ b/src/components/expansion/Expansion.js
@@ -5,11 +5,9 @@ import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 import Typography from "@material-ui/core/Typography";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import { Link } from "react-router-dom";
 import "./expansion.css";
 const useStyles = makeStyles((theme) => ({
-  root: {
-    width: "100%",
-  },
   heading: {
     fontSize: theme.typography.pxToRem(15),
     fontWeight: theme.typography.fontWeightRegular,
@@ -19,19 +17,28 @@ const useStyles = makeStyles((theme) => ({
 export default function SimpleExpansionPanel({
   summary = "Summary for expansion",
   details = "Details for expansionDetails for expansionDetails for expansionDetails for expansionDetails for expansionDetails for expansionDetails for expansionDetails for expansionDetails for expansionDetails for expansion",
+  arrowLink,
+  className,
+  isOpen,
+  routeClose,
+  routeOpen,
 }) {
   const classes = useStyles();
 
   return (
-    <div className={classes.root}>
-      <ExpansionPanel>
-        <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel1a-content"
-          id="panel1a-header"
-        >
-          <Typography className="expansion-panel-summary">{summary}</Typography>
-        </ExpansionPanelSummary>
+    <div className={`${className} expansion-panel`}>
+      <ExpansionPanel expanded={isOpen}>
+        <Link to={isOpen ? routeClose : routeOpen}>
+          <ExpansionPanelSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1a-content"
+            id="panel1a-header"
+          >
+            <Typography className="expansion-panel-summary">
+              {summary}
+            </Typography>
+          </ExpansionPanelSummary>
+        </Link>
         <ExpansionPanelDetails>
           <Typography className="expansion-panel-summary">{details}</Typography>
         </ExpansionPanelDetails>

--- a/src/components/expansion/Expansion.js
+++ b/src/components/expansion/Expansion.js
@@ -28,7 +28,19 @@ export default function SimpleExpansionPanel({
   return (
     <div className={`${className} expansion-panel`}>
       <ExpansionPanel expanded={isOpen}>
-        <Link to={isOpen ? routeClose : routeOpen}>
+        {isOpen ? (
+          <Link to={isOpen ? routeClose : routeOpen}>
+            <ExpansionPanelSummary
+              expandIcon={<ExpandMoreIcon />}
+              aria-controls="panel1a-content"
+              id="panel1a-header"
+            >
+              <Typography className="expansion-panel-summary">
+                {summary}
+              </Typography>
+            </ExpansionPanelSummary>
+          </Link>
+        ) : (
           <ExpansionPanelSummary
             expandIcon={<ExpandMoreIcon />}
             aria-controls="panel1a-content"
@@ -38,7 +50,7 @@ export default function SimpleExpansionPanel({
               {summary}
             </Typography>
           </ExpansionPanelSummary>
-        </Link>
+        )}
         <ExpansionPanelDetails>
           <Typography className="expansion-panel-summary">{details}</Typography>
         </ExpansionPanelDetails>

--- a/src/components/expansion/expansion.css
+++ b/src/components/expansion/expansion.css
@@ -9,4 +9,8 @@
     justify-content: space-between; */
 }
 
+.expansion-panel {
+    width: 100%;
+}
+
 

--- a/src/components/menu/VerticalMenu.js
+++ b/src/components/menu/VerticalMenu.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Menu } from "semantic-ui-react";
 import { Link, useHistory } from "react-router-dom";
-
+import "./menu.css";
 export default function VerticalMenu({ menuData = defaultData, firstActive }) {
   let history = useHistory();
   const [activeItem, setActiveItem] = useState("");
@@ -12,28 +12,48 @@ export default function VerticalMenu({ menuData = defaultData, firstActive }) {
 
   const handleItemClick = (name, route) => {
     history.push(route);
-    
+
     setActiveItem(name);
   };
 
   return (
-    <Menu pointing secondary vertical>
-      {menuData.map((item) => {
-        let routesplit = item.route.split("/");
-        let lowercase = routesplit[2].toLowerCase();
+    <>
+      <Menu pointing secondary tabular className="tabular-menu">
+        {menuData.map((item) => {
+          let routesplit = item.route.split("/");
+          let lowercase = routesplit[2].toLowerCase();
 
-        return (
-          <Menu.Item
-            key={item.route}
-            name={lowercase}
-            active={activeItem === lowercase}
-            onClick={(e) => handleItemClick(lowercase, item.route)}
-          >
-            {item.title}
-          </Menu.Item>
-        );
-      })}
-    </Menu>
+          return (
+            <Menu.Item
+              key={item.route}
+              name={lowercase}
+              active={activeItem === lowercase}
+              onClick={(e) => handleItemClick(lowercase, item.route)}
+            >
+              {item.title}
+            </Menu.Item>
+          );
+        })}
+      </Menu>
+
+      <Menu pointing secondary vertical className="vertical-menu">
+        {menuData.map((item) => {
+          let routesplit = item.route.split("/");
+          let lowercase = routesplit[2].toLowerCase();
+
+          return (
+            <Menu.Item
+              key={item.route}
+              name={lowercase}
+              active={activeItem === lowercase}
+              onClick={(e) => handleItemClick(lowercase, item.route)}
+            >
+              {item.title}
+            </Menu.Item>
+          );
+        })}
+      </Menu>
+    </>
   );
 }
 

--- a/src/components/menu/menu.css
+++ b/src/components/menu/menu.css
@@ -1,0 +1,14 @@
+.tabular-menu {
+    display: none !important;
+}
+
+@media screen and (max-width: 960px) {
+    .tabular-menu {
+        display: flex !important;
+        flex-wrap: wrap;
+    }
+
+    .vertical-menu {
+        display: none !important;
+    }
+  }

--- a/src/pages/customers/Profile.js
+++ b/src/pages/customers/Profile.js
@@ -77,6 +77,7 @@ export default ProfilePage;
 const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 1,
+    padding: "10px 0"
   },
   paper: {
     padding: theme.spacing(2),

--- a/src/pages/customers/Profile.js
+++ b/src/pages/customers/Profile.js
@@ -3,7 +3,7 @@ import { VerticalMenu } from "../../components";
 import { AddPaymentPage, OrderHistory, PaymentPage, View, Edit } from "./index";
 import { makeStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
-import {userManager} from '../../modules';
+import { userManager } from "../../modules";
 
 const ProfilePage = ({ match }) => {
   const [profileView, setProfileView] = useState("");
@@ -13,11 +13,10 @@ const ProfilePage = ({ match }) => {
 
   const getUserData = () => {
     const token = window.sessionStorage.getItem("token");
-    userManager.getCustomer(token)
-      .then(resp => {
-        setUserData(resp)
-      })
-  }
+    userManager.getCustomer(token).then((resp) => {
+      setUserData(resp);
+    });
+  };
 
   useEffect(() => {
     if (match.params.category) {
@@ -36,7 +35,7 @@ const ProfilePage = ({ match }) => {
   return (
     <div className={classes.root}>
       <Grid container spacing={3}>
-        <Grid item xs={2} md={2}>
+        <Grid item xs={12} md={3}>
           {/* 
             Edit Profile doesn't appear in the menu, 
             because it is accessed from an edit button on /profile/view,
@@ -52,17 +51,26 @@ const ProfilePage = ({ match }) => {
             firstActive={profileView}
           />
         </Grid>
-        <Grid item xs={8} md={9}>
-          {profileView === "view" && <View userData={userData} setProfileView={setProfileView}/>}
-          {profileView === "edit" && <Edit userData={userData} setProfileView={setProfileView} getUserData={getUserData}/>}
+        <Grid item xs={12} md={8}>
+          {profileView === "view" && (
+            <View userData={userData} setProfileView={setProfileView} />
+          )}
+          {profileView === "edit" && (
+            <Edit
+              userData={userData}
+              setProfileView={setProfileView}
+              getUserData={getUserData}
+            />
+          )}
           {profileView === "add-payment" && <AddPaymentPage />}
           {profileView === "order-history" && <OrderHistory itemId={itemId} />}
           {profileView === "payment-types" && <PaymentPage />}
         </Grid>
+        <Grid item xs={0} md={1}></Grid>
       </Grid>
     </div>
-  )
-}
+  );
+};
 
 export default ProfilePage;
 

--- a/src/pages/customers/ProfilePages/OrderDetail.js
+++ b/src/pages/customers/ProfilePages/OrderDetail.js
@@ -6,9 +6,9 @@ import { Link } from "react-router-dom";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import "../../../styles/OrderHistory.css";
 
-const OrderDetails = ({ loading, currentOrder }) => {
+const OrderDetails = ({ loading, currentOrder, className }) => {
   return (
-    <Grid item xs={6}>
+    <Grid item xs={12} md={6} className={className}>
       {loading ? (
         <Paper>
           <CircularProgress />
@@ -80,12 +80,13 @@ const OrderDetails = ({ loading, currentOrder }) => {
                         </div>
 
                         <div className="paper-image-container">
-                          <img 
-                            className="paper-image" 
-                            src={item.image_path === null 
-                              ? "https://via.placeholder.com/100" 
-                              : item.image_path
-                            } 
+                          <img
+                            className="paper-image"
+                            src={
+                              item.image_path === null
+                                ? "https://via.placeholder.com/100"
+                                : item.image_path
+                            }
                           />
                         </div>
                       </div>

--- a/src/pages/customers/ProfilePages/OrderHistory.js
+++ b/src/pages/customers/ProfilePages/OrderHistory.js
@@ -109,7 +109,7 @@ const OrderHistory = ({ itemId }) => {
       {/* // Add grid to seperate this into two parts. */}
       <h1>Your Orders</h1>
       <Grid container spacing={0}>
-        <Grid item xs={itemId ? 6 : 12}>
+        <Grid item xs={12} md={itemId ? 6 : 12}>
           {listLoading ? (
             <Paper>
               <CircularProgress />
@@ -117,10 +117,32 @@ const OrderHistory = ({ itemId }) => {
           ) : orderHistory.length > 0 ? (
             orderHistory.map((item) => (
               <Paper key={item.created_at} classProps="order-history-list">
-                <h2>Order placed on: {item.created_at.split("T")[0]}</h2>
-                <Link to={`/profile/order-history/${item.id}`}>
-                  <h3>Details</h3>
-                </Link>
+                <div className="order-details-main-view">
+                  <h2>Order placed on: {item.created_at.split("T")[0]}</h2>
+                  <Link to={`/profile/order-history/${item.id}`}>
+                    <h3>Details</h3>
+                  </Link>
+                </div>
+                <Expansion
+                  className="order-details-mobile-view"
+                  arrowLink={`/profile/order-history/${item.id}`}
+                  summary={
+                    <>
+                      <h2>Order placed on: {item.created_at.split("T")[0]}</h2>
+                    </>
+                  }
+                  details={
+                    item.id == itemId && (
+                      <OrderDetails
+                        currentOrder={currentOrder}
+                        loading={detailsLoading}
+                      />
+                    )
+                  }
+                  routeClose={`/profile/order-history/`}
+                  routeOpen={`/profile/order-history/${item.id}`}
+                  isOpen={item.id == itemId}
+                />
               </Paper>
             ))
           ) : (
@@ -134,7 +156,11 @@ const OrderHistory = ({ itemId }) => {
           )}
         </Grid>
         {itemId && (
-          <OrderDetails currentOrder={currentOrder} loading={detailsLoading} />
+          <OrderDetails
+            className="order-details-main-view"
+            currentOrder={currentOrder}
+            loading={detailsLoading}
+          />
         )}
       </Grid>
     </div>

--- a/src/pages/reports/Reports.js
+++ b/src/pages/reports/Reports.js
@@ -40,6 +40,7 @@ const Reports = ({ match }) => {
 const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 1,
+    padding: "10px 0",
   },
   paper: {
     padding: theme.spacing(2),

--- a/src/pages/reports/Reports.js
+++ b/src/pages/reports/Reports.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { VerticalMenu } from "../../components";
-import {MultipleOpenReports} from "./index";
+import { MultipleOpenReports } from "./index";
 import { makeStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
 
@@ -19,7 +19,7 @@ const Reports = ({ match }) => {
   return (
     <div className={classes.root}>
       <Grid container spacing={3}>
-        <Grid item xs={2} md={2}>
+        <Grid item xs={12} md={3}>
           <VerticalMenu
             menuData={[
               { title: "Multiple Orders", route: "/reports/multiple-orders" },
@@ -27,10 +27,11 @@ const Reports = ({ match }) => {
             firstActive={reportsView}
           />
         </Grid>
-        <Grid item xs={8} md={9}>
+        <Grid item xs={12} md={8}>
           {reportsView === "" && "Choose a report to run"}
-          {reportsView === "multiple-orders" && <MultipleOpenReports/>}
+          {reportsView === "multiple-orders" && <MultipleOpenReports />}
         </Grid>
+        <Grid item xs={0} md={1}></Grid>
       </Grid>
     </div>
   );

--- a/src/styles/Global.css
+++ b/src/styles/Global.css
@@ -7,3 +7,7 @@
 .login-page{
     width: 100vh;
 }
+
+.vertical-menu-sibling{
+    margin: 20px;
+}

--- a/src/styles/OrderHistory.css
+++ b/src/styles/OrderHistory.css
@@ -26,6 +26,11 @@
     padding: 10px;
 }
 
+
+.order-details-mobile-view {
+    display: none;
+}
+
 .order-history-list {
     display: flex;
     padding: 0 15px;
@@ -40,3 +45,13 @@
 .card-expiration-column {
     text-align: left;
 }
+
+@media screen and (max-width: 960px) {
+    .order-details-mobile-view {
+        display: block;
+    }
+
+    .order-details-main-view {
+        display: none !important;
+    }
+  }


### PR DESCRIPTION
Fixes #68

# Fetching Instructions
```shell
git fetch --all
git checkout tct-vertical-responsive
```

# Description
The pages that have vertical menu's are not responsive also Order History menu is responsive

# List of changes
- Added Tabular Menu to Vertical Menu Component
- Updated grid values for profile and report views
- order History page is responsive

# Test
- When screen gets smaller that the vertical menu changes into tabular menu on the top of body for both the Reports pages and Profile pages.
- Check that the links for each menu item in vertical menu still works when on small screen
- Check that the order history's style changes when screen gets smaller.
- Check that the expansion panels for each order on order history page work when the screen is smaller

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation specific to my parts
- [ ] My changes generate no new warnings
- [ ] All tests pass with no new warnings